### PR TITLE
Media hidden if the mediaUrl is not sent

### DIFF
--- a/app/src/main/java/com/example/genericapplication/MainActivity2.kt
+++ b/app/src/main/java/com/example/genericapplication/MainActivity2.kt
@@ -118,6 +118,7 @@ class MainActivity2 : AppCompatActivity() {
         val audioIdentifier = intent.getStringExtra("defaultAudioIdentifier")
         if(audioIdentifier != null)
             return AudioProviderService.buildUrl(audioIdentifier)
+        return null
     }
 
     private fun initializePlayer() {

--- a/app/src/main/java/com/example/genericapplication/MainActivity2.kt
+++ b/app/src/main/java/com/example/genericapplication/MainActivity2.kt
@@ -35,9 +35,9 @@ class MainActivity2 : AppCompatActivity() {
         // Create an AdsLoader.
         this.adsLoader = ImaAdsLoader.Builder(this).build()
         this.textView.text = intent.getStringExtra("title")
-        this.loadWebView()
         this.mediaUrl = this.buildMediaUrl();
         this.hidePlayerViewIfMediaUrlIsNull()
+        this.loadWebView()
     }
 
     private fun hidePlayerViewIfMediaUrlIsNull() {
@@ -111,15 +111,13 @@ class MainActivity2 : AppCompatActivity() {
     }
 
     private fun buildMediaUrl(): String? {
-        if(this.mediaUrl == null) {
-            val videoIdentifier = intent.getStringExtra("defaultVideoIdentifier")
-            val audioIdentifier = intent.getStringExtra("defaultAudioIdentifier")
-            if(videoIdentifier != null)
-                this.mediaUrl = VideoProviderService.buildUrl(videoIdentifier)
-            else if(audioIdentifier != null)
-                this.mediaUrl = AudioProviderService.buildUrl(audioIdentifier)
-        }
-        return this.mediaUrl;
+        val videoIdentifier = intent.getStringExtra("defaultVideoIdentifier")
+        if(videoIdentifier != null)
+            return VideoProviderService.buildUrl(videoIdentifier)
+
+        val audioIdentifier = intent.getStringExtra("defaultAudioIdentifier")
+        if(audioIdentifier != null)
+            return AudioProviderService.buildUrl(audioIdentifier)
     }
 
     private fun initializePlayer() {

--- a/app/src/main/java/com/example/genericapplication/services/AudioProviderService.kt
+++ b/app/src/main/java/com/example/genericapplication/services/AudioProviderService.kt
@@ -2,12 +2,12 @@ package com.example.genericapplication.services
 
 import com.example.genericapplication.factories.DotenvFactory
 
-class VideoProviderService {
+class AudioProviderService {
     companion object {
         fun buildUrl(identifier: String?): String? {
             if(identifier == null)
                 return null
-            return DotenvFactory.getInstance()["VIDEO_PROVIDER_HOST"] + "/" + identifier + ".m3u8"
+            return DotenvFactory.getInstance()["AUDIO_PROVIDER_HOST"] + "/DASH" + identifier
         }
     }
 }


### PR DESCRIPTION
The condition to hide the player is added in case the parameter that makes use of it is not received.

As part of these changes, audio playback is integrated with DASH from its corresponding service that allows generalizing the base `mediaUrl` attribute of the player regardless of whether it is video or audio.

https://user-images.githubusercontent.com/42450812/188485531-c4f5b40d-a75d-464a-8fc6-8017d29bf34a.mp4



